### PR TITLE
Add canary builds and release workflows

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,10 +15,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Extract Go Version
+        id: get-go-version
+        run: |
+          GO_VERSION=$(go mod edit -json | jq -r '.Go')
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Extract version
         id: get_version

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -15,16 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract Go Version
-        id: get-go-version
-        run: |
-          GO_VERSION=$(go mod edit -json | jq -r '.Go')
-          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Extract version
         id: get_version

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,50 @@
+name: Canary
+
+on:
+  workflow_run:
+    workflows: [Go]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: canary
+    strategy:
+        matrix:
+            arch: [ linux/amd64 ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+
+      - name: Extract version
+        id: get_version
+        run: echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y g++ gcc libc6-dev make pkg-config wget
+
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'linux/arm64' }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: ${{ matrix.arch == 'linux/arm64' }}
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run build
+        run: make ubuntu22.04 ubi9 PLATFORMS=${{ matrix.arch }} OUTPUT=type=docker REGISTRY=${{ vars.DOCKERHUB_REGISTRY }} FULL_VERSION=${{ steps.get_version.outputs.VERSION }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push to Docker Hub
+        run: docker images | grep '${{ vars.DOCKERHUB_REGISTRY }}/dcgm-exporter' | awk '{print $1":"$2}' | xargs -I {} sh -c 'docker push {}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,10 @@ jobs:
         with:
           fetch-tags: 1
 
-      - name: Extract Go Version
-        id: get-go-version
-        run: |
-          GO_VERSION=$(go mod edit -json | jq -r '.Go')
-          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: "go.mod"
 
       - name: Extract version
         id: get_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        arch: [ linux/amd64 ]
+    steps:
+      - name: Checkout
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: 1
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21
+
+      - name: Extract version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Run build and tag with version
+        run: make ubuntu22.04 ubi9 PLATFORMS=${{ matrix.arch }} OUTPUT=type=docker REGISTRY=${{ vars.DOCKERHUB_REGISTRY }} NEW_EXPORTER_VERSION=${{ steps.get_version.outputs.VERSION }}
+
+      - name: Run build and tag with latest version
+        run: make ubuntu22.04 ubi9 PLATFORMS=${{ matrix.arch }} OUTPUT=type=docker REGISTRY=${{ vars.DOCKERHUB_REGISTRY }} FULL_VERSION=latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Push to Docker Hub
+        run: docker images | grep '${{ vars.DOCKERHUB_REGISTRY }}/dcgm-exporter' | awk '{print $1":"$2}' | xargs -I {} sh -c 'docker push {}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,16 @@ jobs:
         with:
           fetch-tags: 1
 
+      - name: Extract Go Version
+        id: get-go-version
+        run: |
+          GO_VERSION=$(go mod edit -json | jq -r '.Go')
+          echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Extract version
         id: get_version


### PR DESCRIPTION
This PR adds workflows for canary builds and releases for amd64 arch. It is also ready for arm64, later when it's added to the matrix.

Prereq:

- [x] Create and configure a `release` environment for tags (pattern `v*`)
  - secrets `DOCKERHUB_PASSWORD` and `DOCKERHUB_USERNAME`, and env var `DOCKERHUB_REGISTRY`
- [x] Create and configure a `canary` environment for the `main` branch
  - secrets `DOCKERHUB_PASSWORD` and `DOCKERHUB_USERNAME`, and env var `DOCKERHUB_REGISTRY`  